### PR TITLE
private room でプレイの取り消し可能にする

### DIFF
--- a/specs/flag_reset_spec.md
+++ b/specs/flag_reset_spec.md
@@ -1,0 +1,151 @@
+# プライベートルームでのフラッグリセット機能仕様
+
+## 概要
+プライベートルームにおいて、奪取済みのフラッグを未奪取状態に戻せる機能を追加する。
+操作ミスの救済を目的とし、フラッグを奪取したプレイヤーのみがリセット可能。
+
+---
+
+## 背景
+フラッグ奪取は不可逆な操作であるため、誤操作時のリカバリ手段がなかった。
+パブリックルームでは競技性を維持するため、この機能はプライベートルームに限定する。
+
+---
+
+## 要件
+
+### 1. リセット可能な条件
+| 条件 | 説明 |
+|------|------|
+| ルームタイプ | プライベートルームのみ |
+| 操作可能プレイヤー | そのフラッグを奪取したプレイヤーのみ |
+| タイミング | いつでも可能（自ターン/相手ターン問わず） |
+| ゲーム終了後 | 未定（要確認：ゲーム終了後もリセット可能か？） |
+
+### 2. リセット時の挙動
+| 項目 | 挙動 |
+|------|------|
+| フラッグの `owner` | `null` に戻す |
+| 配置されたカード | そのまま残る（変更なし） |
+| 勝利判定 | リセット後に再評価が必要な場合がある |
+
+### 3. UI
+1. 奪取済みフラッグをクリック
+2. 確認モーダルを表示:「このフラッグを未奪取状態に戻しますか？」
+3. 「はい」でリセット実行、「いいえ」でキャンセル
+
+### 4. 表示条件
+*   プライベートルームでのみ、リセット機能が有効
+*   自分が奪取したフラッグをクリックした場合のみモーダル表示
+*   相手が奪取したフラッグをクリックしても何も起きない
+
+---
+
+## 実装詳細
+
+### 1. データ構造
+
+#### `src/Game.js`（ゲーム状態）
+*   `setup()` の `setupData` からプライベートルーム判定を参照:
+    ```javascript
+    G.isPrivateRoom = setupData?.isPrivate || false;
+    ```
+
+#### `src/types/index.ts`
+*   `GameState` に追加:
+    ```typescript
+    isPrivateRoom: boolean;
+    ```
+
+### 2. ロジック (`src/moves.js`)
+
+#### 新規 move: `resetFlag`
+```javascript
+export const resetFlag = ({ G, ctx, playerID }, flagIndex) => {
+  // 1. プライベートルームのみ許可
+  if (!G.isPrivateRoom) return INVALID_MOVE;
+
+  // 2. フラッグ存在確認
+  const flag = G.flags[flagIndex];
+  if (!flag) return INVALID_MOVE;
+
+  // 3. 奪取済みか確認
+  if (flag.owner === null) return INVALID_MOVE;
+
+  // 4. 自分が奪取したフラッグのみリセット可能
+  if (flag.owner !== playerID) return INVALID_MOVE;
+
+  // 5. リセット実行
+  flag.owner = null;
+};
+```
+
+#### `src/Game.js` への登録
+```javascript
+moves: {
+  // ...existing moves
+  resetFlag,
+},
+```
+
+### 3. UI (`src/board/Board.tsx`)
+
+#### 状態追加
+```typescript
+const [pendingResetFlagIndex, setPendingResetFlagIndex] = useState<number | null>(null);
+```
+
+#### フラッグクリックハンドラの拡張
+```typescript
+const handleFlagClick = (flagIndex: number) => {
+  const flag = G.flags[flagIndex];
+  
+  // 既存のフラッグ確保ロジック...
+  
+  // プライベートルームで自分が奪取したフラッグの場合
+  if (G.isPrivateRoom && flag.owner === playerID) {
+    setPendingResetFlagIndex(flagIndex);
+    return;
+  }
+};
+```
+
+#### リセット確認モーダル
+```tsx
+{pendingResetFlagIndex !== null && (
+  <ConfirmModal
+    title="フラッグリセット"
+    message="このフラッグを未奪取状態に戻しますか？"
+    onConfirm={() => {
+      moves.resetFlag(pendingResetFlagIndex);
+      setPendingResetFlagIndex(null);
+    }}
+    onCancel={() => setPendingResetFlagIndex(null)}
+  />
+)}
+```
+
+### 4. UI (`src/board/MobileBoard.tsx`)
+*   `Board.tsx` と同様の変更
+
+---
+
+## 検証項目
+
+| # | シナリオ | 期待結果 |
+|---|----------|----------|
+| 1 | パブリックルームで奪取済みフラッグをクリック | リセットモーダルが表示されない |
+| 2 | プライベートルームで自分が奪取したフラッグをクリック | リセット確認モーダルが表示される |
+| 3 | プライベートルームで相手が奪取したフラッグをクリック | 何も起きない |
+| 4 | リセット確認で「はい」を選択 | フラッグの `owner` が `null` になる |
+| 5 | リセット確認で「いいえ」を選択 | 何も変わらない |
+| 6 | リセット後、カードが残っていることを確認 | カードはそのまま |
+| 7 | リセット後、再度同じフラッグを奪取可能 | 奪取できる |
+| 8 | 相手のターン中にリセット | リセットできる |
+
+---
+
+## 備考
+
+*   `ConfirmModal` コンポーネントは既存のものを利用（`src/board/ConfirmModal.tsx`）
+*   ゲーム終了判定は現状未実装のため、その考慮は不要

--- a/src/Game.js
+++ b/src/Game.js
@@ -15,6 +15,7 @@ import {
   drawAndEndTurn,
   moveCard,
   claimFlag,
+  resetFlag,
   shuffleDeck,
   endTurn,
   sortHand,
@@ -104,6 +105,7 @@ export const BattleLine = {
       playerNames: { [PLAYER_IDS.P0]: null, [PLAYER_IDS.P1]: null },
       hasPlayedCard: false,
       cardsPlayedThisTurn: [],
+      isPrivateRoom: setupData?.isPrivate || false,
     };
   },
 
@@ -132,6 +134,10 @@ export const BattleLine = {
         drawAndEndTurn,
         moveCard,
         claimFlag,
+        resetFlag: {
+          move: resetFlag,
+          ignoreTurn: true
+        },
         shuffleDeck,
         endTurn,
         sortHand,

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -201,6 +201,7 @@ export const BattleLineBoard = (props: BattleLineBoardProps) => {
     const [discardModalType, setDiscardModalType] = useState<typeof DECK_TYPES.TROOP | typeof DECK_TYPES.TACTIC | null>(null);
     const [infoModalCard, setInfoModalCard] = useState<CardType | null>(null);
     const [pendingFlagIndex, setPendingFlagIndex] = useState<number | null>(null);
+    const [pendingResetFlagIndex, setPendingResetFlagIndex] = useState<number | null>(null);
     const [isDrawModalOpen, setIsDrawModalOpen] = useState(false);
     const [isEndTurnConfirmOpen, setIsEndTurnConfirmOpen] = useState(false);
 
@@ -583,6 +584,11 @@ export const BattleLineBoard = (props: BattleLineBoardProps) => {
                                             myID={myID}
                                             onClaim={(id) => {
                                                 const index = parseInt(id.split('-')[1], 10);
+                                                // プライベートルームで自分が奪取したフラッグの場合、リセットモーダル表示
+                                                if (G.isPrivateRoom && flag.owner === myID) {
+                                                    setPendingResetFlagIndex(index);
+                                                    return;
+                                                }
                                                 if (flag.owner !== null) return;
                                                 if (isMyTurn && !isSpectating && !activeGuileTactic) setPendingFlagIndex(index);
                                             }}
@@ -850,6 +856,19 @@ export const BattleLineBoard = (props: BattleLineBoardProps) => {
                 }}
                 title="フラッグ確保の確認"
                 message="このフラッグを確保しますか？確保後は取り消すことができません。"
+            />
+            <ConfirmModal
+                isOpen={pendingResetFlagIndex !== null}
+                onClose={() => setPendingResetFlagIndex(null)}
+                onConfirm={() => {
+                    if (pendingResetFlagIndex !== null) {
+                        moves.resetFlag(pendingResetFlagIndex);
+                        setPendingResetFlagIndex(null);
+                    }
+                }}
+                title="フラッグリセットの確認"
+                message="このフラッグを未奪取状態に戻しますか？"
+                confirmText="リセットする"
             />
             <ConfirmModal
                 isOpen={isEndTurnConfirmOpen}

--- a/src/board/ConfirmModal.tsx
+++ b/src/board/ConfirmModal.tsx
@@ -6,17 +6,19 @@ interface ConfirmModalProps {
   onConfirm: () => void;
   title: string;
   message: string;
+  confirmText?: string;
+  cancelText?: string;
 }
 
-export function ConfirmModal({ isOpen, onClose, onConfirm, title, message }: ConfirmModalProps) {
+export function ConfirmModal({ isOpen, onClose, onConfirm, title, message, confirmText = '確保する', cancelText = 'キャンセル' }: ConfirmModalProps) {
   if (!isOpen) return null;
 
   return createPortal(
-    <div 
+    <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm animate-in fade-in duration-200"
       onClick={onClose}
     >
-      <div 
+      <div
         className="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl max-w-sm w-full p-6 animate-in zoom-in-95 duration-200"
         role="dialog"
         aria-modal="true"
@@ -24,19 +26,19 @@ export function ConfirmModal({ isOpen, onClose, onConfirm, title, message }: Con
       >
         <h3 className="text-xl font-bold text-zinc-100 mb-2">{title}</h3>
         <p className="text-zinc-400 mb-6 leading-relaxed">{message}</p>
-        
+
         <div className="flex justify-end gap-3">
-          <button 
+          <button
             onClick={onClose}
             className="px-4 py-2 rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-white transition-colors font-medium border border-zinc-700"
           >
-            キャンセル
+            {cancelText}
           </button>
-          <button 
+          <button
             onClick={onConfirm}
             className="px-4 py-2 rounded-lg bg-amber-600 text-white hover:bg-amber-500 shadow-lg shadow-amber-900/20 transition-all font-bold"
           >
-            確保する
+            {confirmText}
           </button>
         </div>
       </div>
@@ -44,3 +46,4 @@ export function ConfirmModal({ isOpen, onClose, onConfirm, title, message }: Con
     document.body
   );
 }
+

--- a/src/board/MobileBoard.tsx
+++ b/src/board/MobileBoard.tsx
@@ -36,6 +36,7 @@ export const MobileBoard = ({ G, ctx, moves, playerID, playerName }: MobileBoard
   const [discardModalType, setDiscardModalType] = useState<typeof DECK_TYPES.TROOP | typeof DECK_TYPES.TACTIC | null>(null);
   const [infoModalCard, setInfoModalCard] = useState<CardType | null>(null);
   const [pendingFlagIndex, setPendingFlagIndex] = useState<number | null>(null);
+  const [pendingResetFlagIndex, setPendingResetFlagIndex] = useState<number | null>(null);
   const [isDrawModalOpen, setIsDrawModalOpen] = useState(false);
   const [isEndTurnConfirmOpen, setIsEndTurnConfirmOpen] = useState(false);
 
@@ -359,6 +360,11 @@ export const MobileBoard = ({ G, ctx, moves, playerID, playerName }: MobileBoard
                       myID={myID}
                       onClaim={(id) => {
                         const index = parseInt(id.split('-')[1], 10);
+                        // プライベートルームで自分が奪取したフラッグの場合、リセットモーダル表示
+                        if (G.isPrivateRoom && flag.owner === myID) {
+                          setPendingResetFlagIndex(index);
+                          return;
+                        }
                         if (flag.owner !== null) return;
                         if (isMyTurn && !isSpectating && !activeGuileTactic) setPendingFlagIndex(index);
                       }}
@@ -484,6 +490,19 @@ export const MobileBoard = ({ G, ctx, moves, playerID, playerName }: MobileBoard
         }}
         title="フラッグ確保の確認"
         message="このフラッグを確保しますか？確保後は取り消すことができません。"
+      />
+      <ConfirmModal
+        isOpen={pendingResetFlagIndex !== null}
+        onClose={() => setPendingResetFlagIndex(null)}
+        onConfirm={() => {
+          if (pendingResetFlagIndex !== null) {
+            moves.resetFlag(pendingResetFlagIndex);
+            setPendingResetFlagIndex(null);
+          }
+        }}
+        title="フラッグリセットの確認"
+        message="このフラッグを未奪取状態に戻しますか？"
+        confirmText="リセットする"
       />
       <ConfirmModal
         isOpen={isEndTurnConfirmOpen}

--- a/src/moves.js
+++ b/src/moves.js
@@ -501,6 +501,24 @@ export const claimFlag = ({ G, ctx }, flagIndex) => {
   flag.owner = ctx.currentPlayer;
 };
 
+export const resetFlag = ({ G, playerID }, flagIndex) => {
+  // 1. プライベートルームのみ許可
+  if (!G.isPrivateRoom) return INVALID_MOVE;
+
+  // 2. フラッグ存在確認
+  const flag = G.flags[flagIndex];
+  if (!flag) return INVALID_MOVE;
+
+  // 3. 奪取済みか確認
+  if (flag.owner === null) return INVALID_MOVE;
+
+  // 4. 自分が奪取したフラッグのみリセット可能
+  if (flag.owner !== playerID) return INVALID_MOVE;
+
+  // 5. リセット実行
+  flag.owner = null;
+};
+
 export const shuffleDeck = ({ G, random }, deckType) => {
   const deck = deckType === DECK_TYPES.TROOP ? G.troopDeck : G.tacticDeck;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,6 +57,7 @@ export interface GameState {
   playerNames: { [playerID: string]: string | null };
   hasPlayedCard: boolean;
   cardsPlayedThisTurn: string[];
+  isPrivateRoom: boolean;
 }
 
 export type LocationInfo = {


### PR DESCRIPTION
- setupDataからisPrivateRoom状態を追加
- resetFlag moveを実装（奪取者のみリセット可能）
- PC版/モバイル版UIにリセット確認モーダルを追加
- ConfirmModalを汎用化（confirmText/cancelText props追加）